### PR TITLE
Fix: Change 'delete' argument to 'uninstall'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,9 +140,9 @@ function renderFiles(files, data) {
  */
 function deleteCmd(helm, namespace, release) {
   if (helm === "helm3") {
-    return ["delete", "-n", namespace, release];
+    return ["uninstall", "-n", namespace, release];
   }
-  return ["delete", "--purge", release];
+  return ["uninstall", "--purge", release];
 }
 
 /**


### PR DESCRIPTION
Helm has changed `delete` argument to `uninstall` since https://github.com/helm/helm/pull/4224.

Even though `delete` argument has been kept as an alias to `uninstall`, to avoid any incompatibilities when https://github.com/helm/helm decide to deprecate/remove `delete`, we will use `uninstall` argument in `deleteCmd()`.
